### PR TITLE
fixes #17: Stop using deprecated Openfire API

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -95,6 +95,7 @@
 
     </li>
     <li><a href="https://github.com/igniterealtime/openfire-jsxc-plugin/issues/14">#14:</a> Update JQuery from 3.5.1 to 3.6.0.</li>
+    <li><a href="https://github.com/igniterealtime/openfire-jsxc-plugin/issues/17">#17:</a> : Replace usage of deprecated Openfire API.</li>
 </ul>
 
 <p><b>4.3.1 Release 1</b> -- August 9, 2021</p>

--- a/plugin.xml
+++ b/plugin.xml
@@ -5,7 +5,7 @@
     <description>${project.description}</description>
     <author>Guus der Kinderen</author>
     <version>${project.version}</version>
-    <date>08/09/2021</date>
+    <date>2022-02-17</date>
     <minServerVersion>4.4.0</minServerVersion>
     <minJavaVersion>1.8</minJavaVersion>
     <adminconsole>

--- a/src/web/jsxc-config.jsp
+++ b/src/web/jsxc-config.jsp
@@ -27,6 +27,8 @@
 <%@ page import="org.igniterealtime.openfire.plugin.jsxc.OptionsServlet" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.ArrayList" %>
+<%@ page import="org.jivesoftware.openfire.spi.ConnectionType" %>
+<%@ page import="org.jivesoftware.openfire.spi.ConnectionManagerImpl" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <jsp:useBean id="webManager" class="org.jivesoftware.util.WebManager"  />
@@ -181,14 +183,14 @@
         <fmt:param value=""/>
     </fmt:message>
     <% if ( httpBindManager.isHttpBindActive() ) {
-        final String unsecuredAddress = "http://" + XMPPServer.getInstance().getServerInfo().getHostname() + ":" + httpBindManager.getHttpBindUnsecurePort() + "/jsxc/";
+        final String unsecuredAddress = "http://" + XMPPServer.getInstance().getServerInfo().getHostname() + ":" + ((ConnectionManagerImpl)XMPPServer.getInstance().getConnectionManager()).getPort(ConnectionType.BOSH_C2S, false) + "/jsxc/";
     %>
         <fmt:message key="config.page.link.unsecure">
             <fmt:param value="<%=unsecuredAddress%>"/>
         </fmt:message>
     <% } %>
     <% if ( httpBindManager.isHttpsBindActive() ) {
-        final String securedAddress = "https://" + XMPPServer.getInstance().getServerInfo().getHostname() + ":" + httpBindManager.getHttpBindSecurePort() + "/jsxc/";
+        final String securedAddress = "https://" + XMPPServer.getInstance().getServerInfo().getHostname() + ":" + ((ConnectionManagerImpl)XMPPServer.getInstance().getConnectionManager()).getPort(ConnectionType.BOSH_C2S, true) + "/jsxc/";
     %>
         <fmt:message key="config.page.link.secure">
             <fmt:param value="<%=securedAddress%>"/>


### PR DESCRIPTION
Replaces calls to Openfire's API that have been deprecated. This should prevent issues when that code is removed from Openfire (likely to happen in Openfire 4.8.0 as part of OF-2395).