### PR TITLE
Release 4.4.0.2

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -43,7 +43,7 @@
     JSXC Plugin Changelog
 </h1>
 
-<p><b>4.5.0 Release 1</b> -- TBD</p>
+<p><b>4.4.0 Release 2</b> -- November 14, 2024</p>
 <ul>
     <li>Marked as last version to be compatible with Openfire versions prior to 5.0.0.</li>
     <li>Added Portuguese translations</li>

--- a/changelog.html
+++ b/changelog.html
@@ -45,7 +45,8 @@
 
 <p><b>4.5.0 Release 1</b> -- TBD</p>
 <ul>
-    <li>Added Portguese translations</li>
+    <li>Marked as last version to be compatible with Openfire versions prior to 5.0.0.</li>
+    <li>Added Portuguese translations</li>
 </ul>
 
 <p><b>4.4.0 Release 1</b> -- April 6, 2022</p>

--- a/changelog.html
+++ b/changelog.html
@@ -47,6 +47,7 @@
 <ul>
     <li>Marked as last version to be compatible with Openfire versions prior to 5.0.0.</li>
     <li>Added Portuguese translations</li>
+    <li><a href="https://github.com/igniterealtime/openfire-jsxc-plugin/issues/22">#22:</a> Update org.json:json from 20180813 to 20240303.</li>
 </ul>
 
 <p><b>4.4.0 Release 1</b> -- April 6, 2022</p>

--- a/plugin.xml
+++ b/plugin.xml
@@ -5,8 +5,9 @@
     <description>${project.description}</description>
     <author>Guus der Kinderen</author>
     <version>${project.version}</version>
-    <date>2022-04-06</date>
+    <date>2024-11-14</date>
     <minServerVersion>4.4.0</minServerVersion>
+    <priorToServerVersion>5.0.0</priorToServerVersion>
     <minJavaVersion>1.8</minJavaVersion>
     <adminconsole>
         <tab id="tab-webclients" name="${admin.sidebar.webclients.name}" description="${admin.sidebar.webclients.description}" url="jsxc-config.jsp">

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>jsxc</artifactId>
-    <version>4.4.0.2</version>
+    <version>4.4.0.3-SNAPSHOT</version>
     <name>JSXC</name>
     <description>Adds the (third-party) JSXC web client to Openfire.</description>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <artifactId>json</artifactId>
             <groupId>org.json</groupId>
-            <version>20180813</version>
+            <version>20240303</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>jsxc</artifactId>
-    <version>4.4.0.2-SNAPSHOT</version>
+    <version>4.4.0.2</version>
     <name>JSXC</name>
     <description>Adds the (third-party) JSXC web client to Openfire.</description>
     <build>


### PR DESCRIPTION
Adds 'prior to' restriction to reflect incompatibility with Openfire 5.0.0 and later (because of the Jetty upgrade).

Updates a dependency that adds JSON support.