### PR TITLE
fixes #24: Compatibility with Openfire 5.0.0

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -43,6 +43,12 @@
     JSXC Plugin Changelog
 </h1>
 
+<p><b>4.4.0 Release 3</b> -- (to be determined)</p>
+<ul>
+    <li>Requires Openfire 5.0.0 or later</li>
+    <li><a href="https://github.com/igniterealtime/openfire-jsxc-plugin/issues/24">#24:</a> Openfire 5.0.0 compatibility</li>
+</ul>
+
 <p><b>4.4.0 Release 2</b> -- November 14, 2024</p>
 <ul>
     <li>Marked as last version to be compatible with Openfire versions prior to 5.0.0.</li>

--- a/plugin.xml
+++ b/plugin.xml
@@ -5,10 +5,8 @@
     <description>${project.description}</description>
     <author>Guus der Kinderen</author>
     <version>${project.version}</version>
-    <date>2024-11-14</date>
-    <minServerVersion>4.4.0</minServerVersion>
-    <priorToServerVersion>5.0.0</priorToServerVersion>
-    <minJavaVersion>1.8</minJavaVersion>
+    <date>2024-11-15</date>
+    <minServerVersion>5.0.0</minServerVersion>
     <adminconsole>
         <tab id="tab-webclients" name="${admin.sidebar.webclients.name}" description="${admin.sidebar.webclients.description}" url="jsxc-config.jsp">
             <sidebar id="tab-jsxc" name="${admin.sidebar.webclients.item.jsxc.name}" description="${admin.sidebar.webclients.item.jsxc.description}">

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.4.0</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>jsxc</artifactId>
@@ -19,8 +19,8 @@
             </plugin>
             <!-- Compiles the Openfire Admin Console JSP pages. -->
             <plugin>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-jspc-maven-plugin</artifactId>
+                <groupId>org.eclipse.jetty.ee8</groupId>
+                <artifactId>jetty-ee8-jspc-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/src/java/org/igniterealtime/openfire/plugin/jsxc/JSXCPlugin.java
+++ b/src/java/org/igniterealtime/openfire/plugin/jsxc/JSXCPlugin.java
@@ -66,8 +66,6 @@ public class JSXCPlugin implements Plugin
         context = new WebAppContext( null, pluginDirectory.getPath() + File.separator + "classes/", "/" + CONTEXT_ROOT );
         context.setClassLoader( this.getClass().getClassLoader() );
 
-        context.setAttribute( InstanceManager.class.getName(), new SimpleInstanceManager());
-
         HttpBindManager.getInstance().addJettyHandler( context );
     }
 

--- a/src/java/org/igniterealtime/openfire/plugin/jsxc/JSXCPlugin.java
+++ b/src/java/org/igniterealtime/openfire/plugin/jsxc/JSXCPlugin.java
@@ -66,10 +66,6 @@ public class JSXCPlugin implements Plugin
         context = new WebAppContext( null, pluginDirectory.getPath() + File.separator + "classes/", "/" + CONTEXT_ROOT );
         context.setClassLoader( this.getClass().getClassLoader() );
 
-        // Ensure the JSP engine is initialized correctly (in order to be able to cope with Tomcat/Jasper precompiled JSPs).
-        final List<ContainerInitializer> initializers = new ArrayList<>();
-        initializers.add( new ContainerInitializer( new JettyJasperInitializer(), null ) );
-        context.setAttribute("org.eclipse.jetty.containerInitializers", initializers);
         context.setAttribute( InstanceManager.class.getName(), new SimpleInstanceManager());
 
         HttpBindManager.getInstance().addJettyHandler( context );

--- a/src/java/org/igniterealtime/openfire/plugin/jsxc/JSXCPlugin.java
+++ b/src/java/org/igniterealtime/openfire/plugin/jsxc/JSXCPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,7 @@
  */
 package org.igniterealtime.openfire.plugin.jsxc;
 
-import org.apache.tomcat.InstanceManager;
-import org.apache.tomcat.SimpleInstanceManager;
-import org.eclipse.jetty.apache.jsp.JettyJasperInitializer;
-import org.eclipse.jetty.plus.annotation.ContainerInitializer;
-import org.eclipse.jetty.webapp.WebAppContext;
+import org.eclipse.jetty.ee8.webapp.WebAppContext;
 import org.jivesoftware.admin.AuthCheckFilter;
 import org.jivesoftware.openfire.container.Plugin;
 import org.jivesoftware.openfire.container.PluginManager;
@@ -30,7 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.util.*;
 
 /**
  * An Openfire plugin that integrates the JSXC web client.


### PR DESCRIPTION
Various commits that make this plugin compatible with Openfire 5.0.0, in particular in context of the update of the embedded webserver (Jetty) that this release contains.