### PR TITLE
Use fixed upstream for nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,9 +30,8 @@ jobs:
 
       - name: JSXC Checkout & Setup
         run: |
-          git clone https://github.com/Fishbowler/jsxc jsxc
+          git clone https://github.com/jsxc/jsxc jsxc
           cd jsxc
-          git checkout fix_webpack_config
           yarn
       
       - name: JSXC Build & Copy Assets


### PR DESCRIPTION
The nightly build was to monitor our compatibility with upstream changes.

It used a "temporary branch" in my fork whilst we awaited a PR to get merged.

Like many temporary things, it hung around a lot longer than it should've...